### PR TITLE
Add OIDC publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+name: Publish to npm (OIDC)
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Publish target ref (tag like v1.0.0 or commit SHA). Empty = release tag."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (release tag or input ref)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref || github.event.release.tag_name }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: npm
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Ensure npm CLI (>= 11.5.1)
+        run: |
+          npm i -g npm@11.5.1
+          npm --version
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Build library
+        run: npm run build:lib
+
+      - name: Dry-run package contents
+        run: npm pack --dry-run
+
+      - name: Publish (public + provenance)
+        run: npm publish --provenance --access public

--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ npm run changeset
 npm run version-packages
 ```
 
+### Release (npm publish)
+
+Publishing is triggered by a GitHub Release (published) via Trusted Publishing (OIDC).
+
+1. Run Changesets and push the version bump to `main`.
+2. Create a GitHub Release with a `vX.Y.Z` tag.
+3. The `Publish to npm (OIDC)` workflow runs `npm publish --provenance --access public`.
+
+Prerequisite: configure the npm package as a Trusted Publisher for this repository and workflow.
+
 ### Styles
 
 Base tokens and component styles are bundled into `dist/styles.css`. If your bundler does not

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
   "types": "dist/index.d.ts",
   "style": "dist/styles.css",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -104,7 +106,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/itdojp/itdo-design-system.git"
+    "url": "git+https://github.com/itdojp/itdo-design-system.git"
   },
   "keywords": [
     "design-system",


### PR DESCRIPTION
## 概要\n- release 起点の OIDC publish ワークフローを追加\n- publishConfig.access と repository.url を更新\n- README にリリース手順を追記\n\n## テスト\n- npm pack --dry-run\n- npm publish --dry-run --access public（ローカルは認証期限切れの警告あり）