### PR TITLE
docs(storybook): add design-book pattern examples

### DIFF
--- a/src/stories/examples/DesignBook.stories.tsx
+++ b/src/stories/examples/DesignBook.stories.tsx
@@ -152,11 +152,9 @@ export const MemoMarkdown: Story = {
                 <MarkdownRenderer
                   content={text}
                   linkComponent={(props) => (
-                    <Link
-                      {...props}
-                      href={props.href ?? '#'}
-                      external={Boolean(props.href?.startsWith('http'))}
-                    />
+                    <Link href={props.href ?? '#'} external={Boolean(props.href?.startsWith('http'))}>
+                      {props.children ?? props.href ?? 'Link'}
+                    </Link>
                   )}
                 />
               </div>


### PR DESCRIPTION
Implements Issue #17 by adding Storybook pattern examples for reference picker, deep link/copy, memo (markdown), and history/audit.\n\n- Reference Picker: scope chips, partial match, type badge, empty state\n- Deep Link & Copy: URL/Markdown copy with labels\n- Memo (Markdown): input/preview with link handling\n- History/Audit: admin override and diff display\n- Pattern Gallery: combined usage