### PR TITLE
chore: bump version to 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+## 1.0.2 - 2026-01-27
+
+### Added
+- Dialog component with focus management and Storybook examples.
+- Popover component for reference pickers and contextual help.
+- Combobox component with async search, keyboard navigation, and empty state support.
+- useClipboard hook and CopyButton for URL/Markdown copy flows.
+- Link component with external/internal defaults and safety handling.
+- MarkdownRenderer with GFM support and configurable link rendering.
+- EventLog extensions for admin override badge and change details.
+- DesignBook Storybook examples for reference, link/copy, memo, and history/audit patterns.
+
+### Changed
+- Added tests for new components/hooks and updated build config to handle CommonJS dependencies.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@itdojp/design-system",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@itdojp/design-system",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itdojp/design-system",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "ITDO Design System - Enterprise-Grade Component Library",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
## Release 1.0.2 (2026-01-27)\n\nThis PR only bumps the version and updates CHANGELOG for changes already merged into main.\n\n### Added\n- Dialog component with focus management and Storybook examples\n- Popover component for reference pickers and contextual help\n- Combobox component with async search, keyboard navigation, and empty state support\n- useClipboard hook and CopyButton for URL/Markdown copy flows\n- Link component with external/internal defaults and safety handling\n- MarkdownRenderer with GFM support and configurable link rendering\n- EventLog extensions for admin override badge and change details\n- DesignBook Storybook examples for reference, link/copy, memo, and history/audit patterns\n\n### Changed\n- Added tests for new components/hooks and updated build config to handle CommonJS dependencies\n\nFiles updated: `package.json`, `package-lock.json`, `CHANGELOG.md`.