### PR TITLE
ci: harden npm publish workflow for tokenless OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,14 +22,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref || github.event.release.tag_name }}
+          ref: ${{ inputs.ref || github.event.release.tag_name || github.ref_name }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: "20.x"
           cache: npm
-          registry-url: "https://registry.npmjs.org"
 
       - name: Ensure npm CLI (>= 11.5.1)
         run: |
@@ -45,5 +44,12 @@ jobs:
       - name: Dry-run package contents
         run: npm pack --dry-run
 
+      - name: Sanitize npm auth for OIDC
+        run: |
+          npm config delete //registry.npmjs.org/:_authToken || true
+          npm config set registry https://registry.npmjs.org
+
       - name: Publish (public + provenance)
+        env:
+          NODE_AUTH_TOKEN: ""
         run: npm publish --provenance --access public


### PR DESCRIPTION
## 概要
- `publish.yml` を tokenless OIDC 前提で補強
- `workflow_dispatch` 実行時の ref 解決を安定化

## 変更点
- checkout ref を `inputs.ref || github.event.release.tag_name || github.ref_name` に変更
- `actions/setup-node` から `registry-url` を削除（不要な npmrc auth 設定を抑制）
- publish 前に npm auth 設定を明示的にクリア
  - `npm config delete //registry.npmjs.org/:_authToken || true`
  - `npm config set registry https://registry.npmjs.org`
- publish step で `NODE_AUTH_TOKEN` を空に固定

## 背景
- `v1.0.2` release で publish run は起動したが、npm publish は E404 で失敗
- run log に token 由来の警告（"Access token expired or revoked"）が混在していたため、OIDC経路を明示固定
- ただし根本原因は npm 側の `@itdojp` スコープ未作成（`npm org ls itdojp` が E404）

## 検証
- workflow ファイル差分のみ（GitHub Actions 実行で確認予定）
