### PR TITLE
chore: switch npm scope to @itdo

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Prerequisite: configure the npm package as a Trusted Publisher for this reposito
 ### Styles
 
 Base tokens and component styles are bundled into `dist/styles.css`. If your bundler does not
-include CSS side effects automatically, import `@itdojp/design-system/styles.css`.
+include CSS side effects automatically, import `@itdo/design-system/styles.css`.
 
 ## Project Structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@itdojp/design-system",
+  "name": "@itdo/design-system",
   "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@itdojp/design-system",
+      "name": "@itdo/design-system",
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@itdojp/design-system",
+  "name": "@itdo/design-system",
   "version": "1.0.2",
   "description": "ITDO Design System - Enterprise-Grade Component Library",
   "main": "dist/index.js",


### PR DESCRIPTION
## 概要
npm 組織が `itdo` である運用実態に合わせ、公開パッケージスコープを `@itdo` に統一します。

## 変更
- `package.json` の `name` を `@itdo/design-system` に変更
- `package-lock.json` の root package name を同期
- README の CSS import 例を `@itdo/design-system/styles.css` に変更

## 背景
- これまでの `@itdojp/design-system` は npm 側スコープ不一致で publish 失敗
- `itdo` 組織での publish 前提に合わせる必要があるため

## 確認
- `npm run lint`
- `npm pack --dry-run`（`@itdo/design-system@1.0.2` として出力されること）
