### PR TITLE
chore: release v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.0.3 - 2026-02-06
+
+### Changed
+- Switched npm package scope from `@itdojp/design-system` to `@itdo/design-system` to align with the npm organization.
+- Hardened npm publish workflow for tokenless Trusted Publishing (OIDC) and explicit npm auth sanitization before publish.
+
 ## 1.0.2 - 2026-01-27
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@itdo/design-system",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@itdo/design-system",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itdo/design-system",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "ITDO Design System - Enterprise-Grade Component Library",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
## 概要
npm 公開運用の継続のため、パッケージバージョンを `1.0.3` に更新します。

## 変更内容
- `package.json` の `version` を `1.0.3` に更新
- `package-lock.json` の root version を `1.0.3` に同期
- `CHANGELOG.md` に `1.0.3` エントリを追加

## 検証
- `npm run lint`
- `npm pack --dry-run`（`@itdo/design-system@1.0.3` を確認）
