### PR TITLE
feat(governance): add quality-gate matrix and telemetry instrumentation sample

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,52 @@ jobs:
           node-version: '20'
           cache: npm
       - name: Install dependencies
+        id: install
         run: npm ci
       - name: Lint
+        id: lint
         run: npm run lint
       - name: Type check
+        id: typecheck
         run: npm run type-check
       - name: Build library
+        id: build_lib
         run: npm run build:lib
       - name: Build Storybook
+        id: build_storybook
         run: npm run build-storybook
       - name: Install Playwright browsers
+        id: playwright
         run: npx playwright install --with-deps
       - name: Storybook a11y tests
+        id: storybook_tests
         timeout-minutes: 20
         run: npm run test-storybook:ci
       - name: Test
+        id: unit_tests
         run: npm test -- --runInBand
+      - name: Quality Gate Summary
+        if: always()
+        run: |
+          {
+            echo "## Quality Gate Summary"
+            echo ""
+            echo "| Gate | Outcome |"
+            echo "| --- | --- |"
+            echo "| install | ${{ steps.install.outcome }} |"
+            echo "| lint | ${{ steps.lint.outcome }} |"
+            echo "| typecheck | ${{ steps.typecheck.outcome }} |"
+            echo "| build_lib | ${{ steps.build_lib.outcome }} |"
+            echo "| build_storybook | ${{ steps.build_storybook.outcome }} |"
+            echo "| playwright | ${{ steps.playwright.outcome }} |"
+            echo "| storybook_tests | ${{ steps.storybook_tests.outcome }} |"
+            echo "| unit_tests | ${{ steps.unit_tests.outcome }} |"
+            echo ""
+            if [ "${{ job.status }}" != "success" ]; then
+              echo "### Failure Triage"
+              echo "1. Reproduce failing gate locally with the same npm command."
+              echo "2. If Storybook tests failed, run: npm run test-storybook:ci"
+              echo "3. If unit tests failed, run: npm test -- --runInBand"
+              echo "4. If build failed, run: npm run build:lib && npm run build-storybook"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ itdo-design-system/
 - `docs/changelog-template.md`: release note template (Breaking/Non-breaking).
 - `docs/wave-review-checklist.md`: wave completion review checklist.
 - `docs/token-system-wave3.md`: token inventory, naming policy, and migration notes for Wave3.
+- `docs/quality-gate-matrix.md`: minimum CI/local quality-gate matrix and triage flow.
+- `docs/telemetry-events.md`: baseline telemetry event naming and payload contract.
 
 ## Design Principles
 

--- a/docs/quality-gate-matrix.md
+++ b/docs/quality-gate-matrix.md
@@ -1,0 +1,32 @@
+# Quality Gate Matrix
+
+This document defines the minimum quality gate set for pull requests.
+
+## Required Gates
+- `lint`: static lint checks for TypeScript/React patterns.
+- `type-check`: TypeScript compile-time contract validation.
+- `test-storybook:ci`: interaction + a11y checks on Storybook stories.
+- `test`: component/unit behavior regression checks.
+- `build:lib`: package output build verification.
+- `build-storybook`: documentation artifact build verification.
+
+## Gate Intent
+- `lint` prevents style and unsafe-pattern drift.
+- `type-check` prevents broken public or internal contracts.
+- `test-storybook:ci` validates usage scenarios and accessibility regressions.
+- `test` validates pure component behavior and hooks logic.
+- `build:lib` ensures distributable package integrity.
+- `build-storybook` ensures docs can be published without breakage.
+
+## Failure Triage
+1. Reproduce locally with the same command.
+2. Isolate whether the failure is deterministic or environment-specific.
+3. If deterministic, fix and add/adjust regression test.
+4. If environment-specific, capture logs and add guardrails in workflow/docs.
+
+## Command Bundle
+Use the consolidated script below for local preflight:
+
+```bash
+npm run test:quality-gate
+```

--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -1,0 +1,34 @@
+# Telemetry Events Specification
+
+This document defines baseline telemetry events for design-system adoption tracking.
+
+## Event Categories
+- `view`: component or pattern view impression.
+- `click`: explicit user interaction on actionable controls.
+- `error`: UI-level recoverable error surfaced to users.
+
+## Event Naming
+- Prefix with `ds.` to indicate design-system emitted events.
+- Use `<surface>.<component>.<action>` naming:
+  - Example: `ds.designbook.datatable.open_detail.click`
+
+## Minimum Payload
+- `eventName`: string
+- `category`: `view | click | error`
+- `surface`: screen or story identifier
+- `component`: component/pattern identifier
+- `target`: action target identifier
+- `status`: `success | error` (for click/error)
+- `occurredAt`: ISO8601 timestamp
+- `metadata`: optional object for domain attributes
+
+## Baseline Event Set
+- `ds.designbook.master_list.view`
+- `ds.designbook.telemetry_panel.view`
+- `ds.designbook.datatable.open_detail.click`
+- `ds.designbook.telemetry.simulate_error.error`
+
+## Operational Notes
+- Events must not contain PII.
+- Keep payload keys stable for dashboard compatibility.
+- Add new events as additive changes in minor versions.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build-storybook": "storybook build",
     "test-storybook": "vitest --project=storybook",
     "test-storybook:ci": "vitest --project=storybook --run",
+    "test:quality-gate": "npm run lint && npm run type-check && npm run build:lib && npm run build-storybook && npm run test-storybook:ci && npm test -- --runInBand",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",


### PR DESCRIPTION
## Summary
- add quality gate matrix docs and consolidated local preflight script (`npm run test:quality-gate`)
- improve CI failure observability by adding per-gate outcomes to GitHub Step Summary
- define telemetry event baseline in docs (`view/click/error` + payload contract)
- add DesignBook telemetry instrumentation sample with interaction test assertions

## Related
- refs #45

## Validation
- npm run type-check
- npm run lint
- npm test -- --runInBand
- npm run test-storybook:ci
- npm run build:lib
- npm run build-storybook
- npm run build