### PR TITLE
feat(waveB): EditableDataGrid基盤を追加 (#56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ itdo-design-system/
 - `docs/bulk-action-guidelines.md`: multi-selection action contract and adapter usage.
 - `docs/saved-view-guidelines.md`: saved view UX contract and persistence integration notes.
 - `docs/command-palette-guidelines.md`: command palette UX contract and integration checklist.
+- `docs/editable-datagrid-guidelines.md`: inline editing/validation contract for editable data grids.
 
 ## Design Principles
 

--- a/docs/editable-datagrid-guidelines.md
+++ b/docs/editable-datagrid-guidelines.md
@@ -1,0 +1,38 @@
+# Editable DataGrid Guidelines
+
+This guide defines baseline rules for `EditableDataGrid` to keep inline editing behavior
+consistent across ITDO business applications.
+
+## UX Contract
+
+- Enter edit mode per row and keep edit scope explicit.
+- Show dirty state before save so users can see pending edits.
+- Keep save and cancel actions visible in the same row context.
+- Surface validation in two layers:
+  - inline error near the field
+  - row-level summary for quick scanning
+
+## API Rules
+
+- Define columns with `EditableDataGridColumnContract`.
+- Use `editor.type` to choose cell editor (`text|number|date|select`).
+- Use `validator` to return field-level messages.
+- Use `onSaveRow` to persist and reconcile with backend state.
+
+## Validation Rules
+
+- Validation messages must be actionable and specific.
+- Required and format violations should use different wording.
+- Validation summary count should match inline errors.
+
+## Do
+
+- Validate before save and block invalid payload submission.
+- Keep keyboard tab order stable while editing.
+- Keep changed fields minimal and pass `changedKeys` to save callback.
+
+## Don't
+
+- Do not silently discard modified values.
+- Do not hide save failure details from users.
+- Do not mix row-level and page-level save semantics in one grid.

--- a/src/patterns/DataGrid/DataGrid.css
+++ b/src/patterns/DataGrid/DataGrid.css
@@ -113,3 +113,86 @@
 .itdo-datagrid-state__error-action {
   display: inline-flex;
 }
+
+.itdo-editable-grid__actions-header {
+  width: 220px;
+}
+
+.itdo-editable-grid__cell {
+  vertical-align: top;
+}
+
+.itdo-editable-grid__editor-wrap {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.itdo-editable-grid__editor {
+  width: 100%;
+  min-height: 32px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+  padding: 0 var(--space-3);
+  font-size: var(--font-size-sm);
+  background: var(--color-bg-base);
+  color: var(--color-text-primary);
+}
+
+.itdo-editable-grid__editor:focus-visible {
+  outline: var(--datagrid-focus-ring-width) solid var(--datagrid-focus-ring);
+  outline-offset: var(--datagrid-focus-ring-offset);
+}
+
+.itdo-editable-grid__cell-error {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-danger-500);
+}
+
+.itdo-editable-grid__actions-cell {
+  min-width: 220px;
+}
+
+.itdo-editable-grid__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.itdo-editable-grid__row-state {
+  margin: var(--space-2) 0 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.itdo-editable-grid__row--dirty {
+  background: color-mix(in srgb, var(--datagrid-row-selected-bg) 55%, var(--color-bg-base));
+}
+
+.itdo-editable-grid__error-summary {
+  margin-top: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-danger-300);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--color-danger-50) 80%, white);
+}
+
+.itdo-editable-grid__error-summary-title {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  color: var(--color-danger-700);
+}
+
+.itdo-editable-grid__error-summary-list {
+  margin: var(--space-2) 0 0;
+  padding-left: 1rem;
+  font-size: var(--font-size-xs);
+  color: var(--color-danger-700);
+}
+
+.itdo-editable-grid__save-error {
+  margin: var(--space-2) 0 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-danger-700);
+}

--- a/src/patterns/DataGrid/EditableDataGrid.stories.tsx
+++ b/src/patterns/DataGrid/EditableDataGrid.stories.tsx
@@ -1,0 +1,170 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useMemo, useState } from 'react';
+import { expect, fireEvent, within } from 'storybook/test';
+import type {
+  EditableDataGridColumnContract,
+  EditableGridRowRecord,
+  EditableGridSavePayload,
+} from '../../types';
+import { EditableDataGrid } from './EditableDataGrid';
+
+type TimesheetRow = EditableGridRowRecord & {
+  member: string;
+  project: string;
+  workDate: string;
+  hours: number;
+  status: string;
+};
+
+const columns: EditableDataGridColumnContract<TimesheetRow>[] = [
+  {
+    key: 'member',
+    header: 'Member',
+    editor: { type: 'text', placeholder: 'Member name' },
+    validator: (value) => (String(value ?? '').trim().length === 0 ? 'Member is required.' : null),
+  },
+  {
+    key: 'project',
+    header: 'Project',
+    editor: {
+      type: 'select',
+      options: [
+        { label: 'ERP4 Core', value: 'ERP4 Core' },
+        { label: 'ERP4 Timesheet', value: 'ERP4 Timesheet' },
+        { label: 'ERP4 Approval', value: 'ERP4 Approval' },
+      ],
+    },
+    validator: (value) => (String(value ?? '').trim().length === 0 ? 'Project is required.' : null),
+  },
+  {
+    key: 'workDate',
+    header: 'Work Date',
+    editor: { type: 'date' },
+    validator: (value) => (String(value ?? '').trim().length === 0 ? 'Work date is required.' : null),
+  },
+  {
+    key: 'hours',
+    header: 'Hours',
+    align: 'right',
+    editor: { type: 'number', min: 0, max: 24, step: 0.5 },
+    validator: (value) => {
+      if (typeof value !== 'number') {
+        return 'Hours must be numeric.';
+      }
+      if (value <= 0) {
+        return 'Hours must be greater than 0.';
+      }
+      if (value > 24) {
+        return 'Hours must be 24 or less.';
+      }
+      return null;
+    },
+    formatter: (value) => (typeof value === 'number' ? value.toFixed(1) : String(value ?? '')),
+  },
+  {
+    key: 'status',
+    header: 'Status',
+    editor: {
+      type: 'select',
+      options: [
+        { label: 'Open', value: 'Open' },
+        { label: 'Pending', value: 'Pending' },
+        { label: 'Approved', value: 'Approved' },
+      ],
+    },
+  },
+];
+
+const initialRows: TimesheetRow[] = [
+  {
+    id: 'TS-001',
+    member: 'Sato',
+    project: 'ERP4 Timesheet',
+    workDate: '2026-02-08',
+    hours: 7.5,
+    status: 'Open',
+  },
+  {
+    id: 'TS-002',
+    member: 'Tanaka',
+    project: 'ERP4 Core',
+    workDate: '2026-02-08',
+    hours: 8,
+    status: 'Pending',
+  },
+];
+
+const meta: Meta<typeof EditableDataGrid<TimesheetRow>> = {
+  title: 'Patterns/DataGrid/EditableDataGrid',
+  component: EditableDataGrid<TimesheetRow>,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof EditableDataGrid<TimesheetRow>>;
+
+export const Default: Story = {
+  render: () => {
+    const [rows, setRows] = useState(initialRows);
+    const [lastSave, setLastSave] = useState<string>('No save yet');
+
+    const handleSave = async (payload: EditableGridSavePayload<TimesheetRow>) => {
+      setRows((previous) =>
+        previous.map((row) => (row.id === payload.rowId ? payload.nextRow : row))
+      );
+      setLastSave(`${payload.rowId}: ${payload.changedKeys.join(', ')}`);
+    };
+
+    return (
+      <div style={{ display: 'grid', gap: 'var(--space-6)' }}>
+        <EditableDataGrid<TimesheetRow>
+          caption="Timesheet entries"
+          columns={columns}
+          rows={rows}
+          onSaveRow={handleSave}
+        />
+        <p style={{ margin: 0, color: 'var(--color-text-secondary)' }} data-testid="editable-grid-last-save">
+          {lastSave}
+        </p>
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Sato')).toBeInTheDocument();
+    fireEvent.click(canvas.getAllByRole('button', { name: 'Edit' })[0]);
+    const hoursField = canvas.getByLabelText('Hours for row TS-001');
+    fireEvent.change(hoursField, { target: { value: '8.5' } });
+    fireEvent.click(canvas.getByRole('button', { name: 'Save' }));
+    await expect(canvas.getByTestId('editable-grid-last-save')).toHaveTextContent('TS-001');
+  },
+};
+
+export const ValidationError: Story = {
+  render: () => {
+    const [rows, setRows] = useState(initialRows);
+    const validationColumns = useMemo(() => columns, []);
+
+    return (
+      <EditableDataGrid<TimesheetRow>
+        caption="Timesheet entries"
+        columns={validationColumns}
+        rows={rows}
+        onSaveRow={async (payload) => {
+          setRows((previous) =>
+            previous.map((row) => (row.id === payload.rowId ? payload.nextRow : row))
+          );
+        }}
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    fireEvent.click(canvas.getAllByRole('button', { name: 'Edit' })[0]);
+    fireEvent.change(canvas.getByLabelText('Member for row TS-001'), {
+      target: { value: '' },
+    });
+    fireEvent.click(canvas.getByRole('button', { name: 'Save' }));
+    await expect(canvas.getAllByText('Member is required.')).toHaveLength(2);
+  },
+};

--- a/src/patterns/DataGrid/EditableDataGrid.test.tsx
+++ b/src/patterns/DataGrid/EditableDataGrid.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { EditableDataGrid } from './EditableDataGrid';
+import type { EditableDataGridColumnContract, EditableGridRowRecord } from '../../types';
+
+type TestRow = EditableGridRowRecord & {
+  member: string;
+  hours: number;
+  status: string;
+};
+
+const columns: EditableDataGridColumnContract<TestRow>[] = [
+  {
+    key: 'member',
+    header: 'Member',
+    editor: { type: 'text' },
+    validator: (value) => (String(value ?? '').trim().length === 0 ? 'Member is required.' : null),
+  },
+  {
+    key: 'hours',
+    header: 'Hours',
+    editor: { type: 'number', min: 0, max: 24, step: 0.5 },
+    validator: (value) => (typeof value === 'number' && value > 0 ? null : 'Hours must be greater than 0.'),
+  },
+  {
+    key: 'status',
+    header: 'Status',
+    editor: {
+      type: 'select',
+      options: [
+        { label: 'Open', value: 'Open' },
+        { label: 'Pending', value: 'Pending' },
+      ],
+    },
+  },
+];
+
+const rows: TestRow[] = [
+  { id: 'TS-001', member: 'Sato', hours: 7.5, status: 'Open' },
+  { id: 'TS-002', member: 'Tanaka', hours: 8, status: 'Pending' },
+];
+
+describe('EditableDataGrid', () => {
+  it('renders editors and saves dirty row', async () => {
+    const onSaveRow = jest.fn().mockResolvedValue(undefined);
+
+    render(<EditableDataGrid<TestRow> columns={columns} rows={rows} onSaveRow={onSaveRow} />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Edit' })[0]);
+    fireEvent.change(screen.getByLabelText('Hours for row TS-001'), { target: { value: '8.5' } });
+
+    expect(screen.getByText('Unsaved changes')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(onSaveRow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rowId: 'TS-001',
+          changedKeys: ['hours'],
+        })
+      );
+    });
+  });
+
+  it('shows inline and summary errors when validation fails', async () => {
+    const onSaveRow = jest.fn().mockResolvedValue(undefined);
+
+    render(<EditableDataGrid<TestRow> columns={columns} rows={rows} onSaveRow={onSaveRow} />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Edit' })[0]);
+    fireEvent.change(screen.getByLabelText('Member for row TS-001'), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(screen.getAllByText('Member is required.')).toHaveLength(2);
+    expect(screen.getByText('1 validation error(s)')).toBeInTheDocument();
+    expect(onSaveRow).not.toHaveBeenCalled();
+  });
+
+  it('cancels row edit and restores read mode', () => {
+    render(<EditableDataGrid<TestRow> columns={columns} rows={rows} />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Edit' })[0]);
+    fireEvent.change(screen.getByLabelText('Member for row TS-001'), { target: { value: 'Updated' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.getByText('Sato')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Member for row TS-001')).not.toBeInTheDocument();
+  });
+});

--- a/src/patterns/DataGrid/EditableDataGrid.tsx
+++ b/src/patterns/DataGrid/EditableDataGrid.tsx
@@ -1,0 +1,414 @@
+import { useEffect, useMemo, useState } from 'react';
+import clsx from 'clsx';
+import { Button } from '../../components/Button';
+import { Spinner } from '../../components/Spinner';
+import type {
+  EditableDataGridColumnContract,
+  EditableGridEditorType,
+  EditableGridRowRecord,
+  EditableGridSavePayload,
+} from '../../types';
+import type { EditableDataGridProps } from './EditableDataGrid.types';
+import './DataGrid.css';
+
+type RowValidationErrors = Record<string, string>;
+
+const getEditorType = <TRow extends EditableGridRowRecord>(
+  column: EditableDataGridColumnContract<TRow>
+): EditableGridEditorType =>
+  column.editor?.type ?? 'text';
+
+const toInputValue = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value);
+};
+
+const toEditorValue = (editorType: EditableGridEditorType, rawValue: string): unknown => {
+  if (editorType !== 'number') {
+    return rawValue;
+  }
+
+  if (rawValue.trim().length === 0) {
+    return null;
+  }
+
+  const parsed = Number(rawValue);
+  return Number.isNaN(parsed) ? rawValue : parsed;
+};
+
+const getHeaderText = <TRow extends EditableGridRowRecord>(
+  column: EditableDataGridColumnContract<TRow>
+): string =>
+  typeof column.header === 'string' ? column.header : column.key;
+
+const resolveCellContent = <TRow extends EditableGridRowRecord>(
+  column: EditableDataGridColumnContract<TRow>,
+  row: TRow
+) => {
+  const value = row[column.key];
+  if (column.formatter) {
+    return column.formatter(value, row);
+  }
+  return toInputValue(value);
+};
+
+const validateDraftRow = <TRow extends EditableGridRowRecord>(
+  columns: EditableDataGridColumnContract<TRow>[],
+  row: TRow
+): RowValidationErrors => {
+  const errors: RowValidationErrors = {};
+
+  for (const column of columns) {
+    if (column.editable === false || !column.validator) {
+      continue;
+    }
+
+    const message = column.validator(row[column.key], { row, columnKey: column.key });
+    if (message) {
+      errors[column.key] = message;
+    }
+  }
+
+  return errors;
+};
+
+const removeMapEntry = <T extends Record<string, unknown>>(source: T, key: string): T => {
+  if (!(key in source)) {
+    return source;
+  }
+  const next = { ...source };
+  delete next[key];
+  return next;
+};
+
+export const EditableDataGrid = <TRow extends EditableGridRowRecord = EditableGridRowRecord>({
+  columns,
+  rows,
+  caption,
+  className,
+  emptyState,
+  loading = false,
+  loadingLabel = 'Loading rows...',
+  onSaveRow,
+  onCancelRow,
+  labels,
+}: EditableDataGridProps<TRow>) => {
+  const [localRows, setLocalRows] = useState(rows);
+  const [draftRows, setDraftRows] = useState<Record<string, TRow>>({});
+  const [rowErrors, setRowErrors] = useState<Record<string, RowValidationErrors>>({});
+  const [savingRowIds, setSavingRowIds] = useState<string[]>([]);
+  const [saveFailures, setSaveFailures] = useState<Record<string, string>>({});
+
+  const resolvedLabels = {
+    noRows: labels?.noRows ?? 'No records found.',
+    editRow: labels?.editRow ?? 'Edit',
+    saveRow: labels?.saveRow ?? 'Save',
+    cancelRow: labels?.cancelRow ?? 'Cancel',
+    unsavedState: labels?.unsavedState ?? 'Unsaved changes',
+    validationSummaryTitle:
+      labels?.validationSummaryTitle ?? ((count: number) => `${count} validation error(s)`),
+    saveErrorPrefix: labels?.saveErrorPrefix ?? 'Save failed',
+  };
+
+  useEffect(() => {
+    setLocalRows(rows);
+  }, [rows]);
+
+  const editableColumns = useMemo(
+    () => columns.filter((column) => column.editable !== false),
+    [columns]
+  );
+
+  const canEditRows = editableColumns.length > 0;
+
+  const updateDraftCell = (rowId: string, column: EditableDataGridColumnContract<TRow>, rawValue: string) => {
+    const editorType = getEditorType(column);
+    const nextValue = toEditorValue(editorType, rawValue);
+
+    setDraftRows((previous) => {
+      const currentDraft = previous[rowId];
+      if (!currentDraft) {
+        return previous;
+      }
+      return {
+        ...previous,
+        [rowId]: {
+          ...currentDraft,
+          [column.key]: nextValue,
+        },
+      };
+    });
+
+    setRowErrors((previous) => {
+      const rowLevel = previous[rowId];
+      if (!rowLevel || !(column.key in rowLevel)) {
+        return previous;
+      }
+      const nextRowLevel = { ...rowLevel };
+      delete nextRowLevel[column.key];
+      return {
+        ...previous,
+        [rowId]: nextRowLevel,
+      };
+    });
+  };
+
+  const beginRowEdit = (row: TRow) => {
+    setDraftRows((previous) => ({
+      ...previous,
+      [row.id]: { ...row },
+    }));
+    setRowErrors((previous) => removeMapEntry(previous, row.id));
+    setSaveFailures((previous) => removeMapEntry(previous, row.id));
+  };
+
+  const cancelRowEdit = (row: TRow) => {
+    setDraftRows((previous) => removeMapEntry(previous, row.id));
+    setRowErrors((previous) => removeMapEntry(previous, row.id));
+    setSaveFailures((previous) => removeMapEntry(previous, row.id));
+    onCancelRow?.(row);
+  };
+
+  const getChangedKeys = (row: TRow, draftRow: TRow): string[] =>
+    editableColumns
+      .map((column) => column.key)
+      .filter((columnKey) => !Object.is(row[columnKey], draftRow[columnKey]));
+
+  const saveRow = async (row: TRow) => {
+    const draftRow = draftRows[row.id];
+    if (!draftRow) {
+      return;
+    }
+
+    const nextErrors = validateDraftRow(columns, draftRow);
+    if (Object.keys(nextErrors).length > 0) {
+      setRowErrors((previous) => ({
+        ...previous,
+        [row.id]: nextErrors,
+      }));
+      return;
+    }
+
+    const changedKeys = getChangedKeys(row, draftRow);
+    if (changedKeys.length === 0) {
+      cancelRowEdit(row);
+      return;
+    }
+
+    setSavingRowIds((previous) => [...previous, row.id]);
+    setSaveFailures((previous) => removeMapEntry(previous, row.id));
+
+    try {
+      const payload: EditableGridSavePayload<TRow> = {
+        rowId: row.id,
+        previousRow: row,
+        nextRow: draftRow,
+        changedKeys,
+      };
+      await onSaveRow?.(payload);
+
+      setLocalRows((previous) =>
+        previous.map((currentRow) => (currentRow.id === row.id ? draftRow : currentRow))
+      );
+
+      setDraftRows((previous) => removeMapEntry(previous, row.id));
+      setRowErrors((previous) => removeMapEntry(previous, row.id));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown save error';
+      setSaveFailures((previous) => ({
+        ...previous,
+        [row.id]: message,
+      }));
+    } finally {
+      setSavingRowIds((previous) => previous.filter((targetId) => targetId !== row.id));
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className={clsx('itdo-datagrid', 'itdo-editable-grid', className)}>
+        <div className="itdo-datagrid-state">
+          <span className="itdo-datagrid-state__loading">
+            <Spinner size="small" />
+            <span className="itdo-datagrid-state__text">{loadingLabel}</span>
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  if (localRows.length === 0) {
+    return (
+      <div className={clsx('itdo-datagrid', 'itdo-editable-grid', className)}>
+        {emptyState ?? (
+          <div className="itdo-datagrid-state">
+            <p className="itdo-datagrid-state__text">{resolvedLabels.noRows}</p>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className={clsx('itdo-datagrid', 'itdo-editable-grid', className)}>
+      <table className="itdo-datagrid__table" role="grid">
+        {caption && <caption>{caption}</caption>}
+        <thead>
+          <tr className="itdo-datagrid__header-row">
+            {columns.map((column) => (
+              <th
+                key={column.key}
+                className="itdo-datagrid__header-cell"
+                style={{ width: column.width, textAlign: column.align ?? 'left' }}
+                scope="col"
+              >
+                {column.header}
+              </th>
+            ))}
+            <th className="itdo-datagrid__header-cell itdo-editable-grid__actions-header" scope="col">
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {localRows.map((row) => {
+            const draftRow = draftRows[row.id];
+            const rowModel = draftRow ?? row;
+            const isEditing = !!draftRow;
+            const changedKeys = draftRow ? getChangedKeys(row, draftRow) : [];
+            const isDirty = changedKeys.length > 0;
+            const errors = rowErrors[row.id] ?? {};
+            const errorMessages = Object.values(errors);
+            const saveFailure = saveFailures[row.id];
+            const isSaving = savingRowIds.includes(row.id);
+
+            return (
+              <tr
+                key={row.id}
+                className={clsx('itdo-datagrid__row', {
+                  'itdo-editable-grid__row--dirty': isDirty,
+                })}
+                data-state={isDirty ? 'dirty' : undefined}
+              >
+                {columns.map((column) => {
+                  const cellValue = rowModel[column.key];
+                  const cellError = errors[column.key];
+                  const fieldId = `itdo-editable-grid-${row.id}-${column.key}`;
+                  const errorId = `${fieldId}-error`;
+                  const isColumnEditable = column.editable !== false;
+
+                  return (
+                    <td
+                      key={`${row.id}-${column.key}`}
+                      className="itdo-datagrid__cell itdo-editable-grid__cell"
+                      style={{ textAlign: column.align ?? 'left' }}
+                    >
+                      {isEditing && isColumnEditable ? (
+                        <div className="itdo-editable-grid__editor-wrap">
+                          {getEditorType(column) === 'select' ? (
+                            <select
+                              id={fieldId}
+                              className="itdo-editable-grid__editor"
+                              aria-label={`${getHeaderText(column)} for row ${row.id}`}
+                              aria-invalid={cellError ? true : undefined}
+                              aria-describedby={cellError ? errorId : undefined}
+                              value={toInputValue(cellValue)}
+                              onChange={(event) => updateDraftCell(row.id, column, event.target.value)}
+                            >
+                              <option value="">Select...</option>
+                              {(column.editor?.options ?? []).map((option) => (
+                                <option key={`${column.key}-${option.value}`} value={option.value}>
+                                  {option.label}
+                                </option>
+                              ))}
+                            </select>
+                          ) : (
+                            <input
+                              id={fieldId}
+                              className="itdo-editable-grid__editor"
+                              aria-label={`${getHeaderText(column)} for row ${row.id}`}
+                              aria-invalid={cellError ? true : undefined}
+                              aria-describedby={cellError ? errorId : undefined}
+                              type={getEditorType(column)}
+                              min={column.editor?.min}
+                              max={column.editor?.max}
+                              step={column.editor?.step}
+                              placeholder={column.editor?.placeholder}
+                              value={toInputValue(cellValue)}
+                              onChange={(event) => updateDraftCell(row.id, column, event.target.value)}
+                            />
+                          )}
+                          {cellError && (
+                            <p id={errorId} className="itdo-editable-grid__cell-error" role="alert">
+                              {cellError}
+                            </p>
+                          )}
+                        </div>
+                      ) : (
+                        resolveCellContent(column, rowModel)
+                      )}
+                    </td>
+                  );
+                })}
+                <td className="itdo-datagrid__cell itdo-editable-grid__actions-cell">
+                  <div className="itdo-editable-grid__actions">
+                    {isEditing ? (
+                      <>
+                        <Button
+                          size="small"
+                          onClick={() => {
+                            void saveRow(row);
+                          }}
+                          disabled={isSaving}
+                        >
+                          {resolvedLabels.saveRow}
+                        </Button>
+                        <Button
+                          size="small"
+                          variant="secondary"
+                          onClick={() => cancelRowEdit(row)}
+                          disabled={isSaving}
+                        >
+                          {resolvedLabels.cancelRow}
+                        </Button>
+                      </>
+                    ) : (
+                      <Button
+                        size="small"
+                        variant="secondary"
+                        onClick={() => beginRowEdit(row)}
+                        disabled={!canEditRows}
+                      >
+                        {resolvedLabels.editRow}
+                      </Button>
+                    )}
+                  </div>
+                  {isDirty && <p className="itdo-editable-grid__row-state">{resolvedLabels.unsavedState}</p>}
+                  {errorMessages.length > 0 && (
+                    <div className="itdo-editable-grid__error-summary" role="alert">
+                      <p className="itdo-editable-grid__error-summary-title">
+                        {resolvedLabels.validationSummaryTitle(errorMessages.length)}
+                      </p>
+                      <ul className="itdo-editable-grid__error-summary-list">
+                        {errorMessages.map((message, index) => (
+                          <li key={`${row.id}-summary-${index}`}>{message}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {saveFailure && (
+                    <p className="itdo-editable-grid__save-error" role="alert">
+                      {resolvedLabels.saveErrorPrefix}: {saveFailure}
+                    </p>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/src/patterns/DataGrid/EditableDataGrid.types.ts
+++ b/src/patterns/DataGrid/EditableDataGrid.types.ts
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+import type {
+  EditableDataGridColumnContract,
+  EditableGridRowRecord,
+  EditableGridSavePayload,
+} from '../../types';
+
+export interface EditableDataGridLabels {
+  noRows?: string;
+  editRow?: string;
+  saveRow?: string;
+  cancelRow?: string;
+  unsavedState?: string;
+  validationSummaryTitle?: (count: number) => string;
+  saveErrorPrefix?: string;
+}
+
+export interface EditableDataGridProps<TRow extends EditableGridRowRecord = EditableGridRowRecord> {
+  columns: EditableDataGridColumnContract<TRow>[];
+  rows: TRow[];
+  caption?: string;
+  className?: string;
+  emptyState?: ReactNode;
+  loading?: boolean;
+  loadingLabel?: string;
+  onSaveRow?: (payload: EditableGridSavePayload<TRow>) => Promise<void> | void;
+  onCancelRow?: (row: TRow) => void;
+  labels?: EditableDataGridLabels;
+}

--- a/src/patterns/DataGrid/index.ts
+++ b/src/patterns/DataGrid/index.ts
@@ -5,3 +5,5 @@ export * from './DataGridEmptyState';
 export * from './DataGridLoadingState';
 export * from './DataGridErrorState';
 export * from './DataGrid.types';
+export * from './EditableDataGrid';
+export * from './EditableDataGrid.types';

--- a/src/types/editable-grid.ts
+++ b/src/types/editable-grid.ts
@@ -1,0 +1,55 @@
+import type { ReactNode } from 'react';
+
+export interface EditableGridRowRecord {
+  id: string;
+  [key: string]: unknown;
+}
+
+export type EditableGridEditorType = 'text' | 'number' | 'date' | 'select';
+
+export interface EditableGridSelectOption {
+  label: string;
+  value: string;
+}
+
+export interface EditableGridEditorContract {
+  type?: EditableGridEditorType;
+  placeholder?: string;
+  options?: EditableGridSelectOption[];
+  min?: number;
+  max?: number;
+  step?: number;
+}
+
+export interface EditableGridValidationContext<TRow extends EditableGridRowRecord> {
+  row: TRow;
+  columnKey: string;
+}
+
+export type EditableGridValidator<TRow extends EditableGridRowRecord> = (
+  value: unknown,
+  context: EditableGridValidationContext<TRow>
+) => string | null;
+
+export interface EditableDataGridColumnContract<TRow extends EditableGridRowRecord = EditableGridRowRecord> {
+  key: string;
+  header: string | ReactNode;
+  align?: 'left' | 'center' | 'right';
+  width?: string;
+  editable?: boolean;
+  editor?: EditableGridEditorContract;
+  validator?: EditableGridValidator<TRow>;
+  formatter?: (value: unknown, row: TRow) => ReactNode;
+}
+
+export interface EditableGridValidationErrorRecord {
+  columnKey: string;
+  message: string;
+}
+
+export interface EditableGridSavePayload<TRow extends EditableGridRowRecord = EditableGridRowRecord> {
+  rowId: string;
+  nextRow: TRow;
+  previousRow: TRow;
+  changedKeys: string[];
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,4 +3,5 @@ export type Variant = 'primary' | 'secondary' | 'success' | 'warning' | 'error' 
 export type ColorScheme = 'light' | 'dark';
 
 export * from './saved-view';
+export * from './editable-grid';
 export * from './command';


### PR DESCRIPTION
## 概要
Issue #56 (WaveB) のバッチB1として、`EditableDataGrid` を追加しました。

実施内容:
- `EditableDataGrid` API契約を追加（`src/types/editable-grid.ts`）
- `EditableDataGrid` 本体を追加（行単位編集、dirty state、保存/取消）
- セル編集エディタを追加（text/select/date/number）
- バリデーション表示を統一（inline + row summary）
- Storybook stories を追加（Default / Validation Error）
- Jestテストを追加
- ガイド文書を追加（`docs/editable-datagrid-guidelines.md`）

## 破壊的変更
なし

## 検証
- `npm run lint`
- `npm run type-check`
- `npm test -- --runInBand`
- `npm run build`
- `npm run test-storybook:ci`
- `npm run test:visual`

## 対応TODO（Issue #56）
- [x] `EditableDataGrid` API（列ごとのeditor/validator）を定義
- [x] セル編集コンポーネント（text/select/date/number）を実装
- [x] 行単位のdirty state・保存/取消制御を実装
- [x] バリデーションエラー表示契約を統一（inline + summary）
