### PR TITLE
feat: AuditTimeline / DiffViewer を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ itdo-design-system/
 - `docs/saved-view-guidelines.md`: saved view UX contract and persistence integration notes.
 - `docs/command-palette-guidelines.md`: command palette UX contract and integration checklist.
 - `docs/form-wizard-guidelines.md`: step navigation, autosave, and leave-guard rules for wizard flows.
+- `docs/audit-timeline-guidelines.md`: boundaries between EventLog and timeline+diff investigation flows.
 - `docs/editable-datagrid-guidelines.md`: inline editing/validation contract for editable data grids.
 - `docs/attachment-ux-guidelines.md`: upload status, retry, and preview behavior rules.
 - `docs/reliability-ux-guidelines.md`: undo notification and state preset recovery contracts.

--- a/docs/audit-timeline-guidelines.md
+++ b/docs/audit-timeline-guidelines.md
@@ -1,0 +1,31 @@
+# Audit Timeline Guidelines
+
+This guide defines boundaries between `EventLog` and `AuditTimeline` / `DiffViewer`.
+
+## EventLog vs AuditTimeline
+
+- Use `EventLog` for compact activity summaries in transactional screens.
+- Use `AuditTimeline` when operators need chronological investigation:
+  - incident analysis
+  - policy change tracing
+  - multi-step override history
+
+## DiffViewer Usage
+
+- Pair `DiffViewer` with selected timeline events for before/after investigation.
+- Use `format="json"` for structured policy/config diffs.
+- Use `format="text"` for log snippets and plain configuration entries.
+
+## Performance Contract
+
+- For long outputs, keep initial render bounded via `maxVisibleLines`.
+- Enable compact mode where vertical space is constrained.
+- Default to collapsed view for large diffs and expand on demand.
+
+## Tone and Priority
+
+- Map event tone by operational severity:
+  - `success`: expected completed operation
+  - `warning`: unusual but recoverable
+  - `error`/`critical`: requires immediate operator attention
+- Keep tone mapping stable across products to reduce cognitive load.

--- a/src/patterns/AuditTimeline/AuditTimeline.css
+++ b/src/patterns/AuditTimeline/AuditTimeline.css
@@ -1,0 +1,212 @@
+.itdo-audit-timeline {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.itdo-audit-timeline__empty {
+  margin: 0;
+  color: var(--color-neutral-600, #4b5563);
+}
+
+.itdo-audit-timeline__group {
+  display: grid;
+  gap: 0.375rem;
+}
+
+.itdo-audit-timeline__date {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--color-neutral-600, #4b5563);
+}
+
+.itdo-audit-timeline__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.itdo-audit-timeline__item {
+  border: 1px solid var(--color-border-default, #e5e7eb);
+  border-radius: 0.5rem;
+  background: var(--color-neutral-0, #ffffff);
+}
+
+.itdo-audit-timeline__item-button,
+.itdo-audit-timeline__item-static {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5rem;
+  text-align: left;
+  padding: 0.625rem 0.75rem;
+}
+
+.itdo-audit-timeline__item-button {
+  cursor: pointer;
+}
+
+.itdo-audit-timeline__item-button:hover {
+  background: var(--color-neutral-50, #f9fafb);
+}
+
+.itdo-audit-timeline__dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  margin-top: 0.375rem;
+  background: var(--color-neutral-400, #9ca3af);
+}
+
+.itdo-audit-timeline__item--info .itdo-audit-timeline__dot {
+  background: #2563eb;
+}
+
+.itdo-audit-timeline__item--success .itdo-audit-timeline__dot {
+  background: #059669;
+}
+
+.itdo-audit-timeline__item--warning .itdo-audit-timeline__dot {
+  background: #d97706;
+}
+
+.itdo-audit-timeline__item--error .itdo-audit-timeline__dot,
+.itdo-audit-timeline__item--critical .itdo-audit-timeline__dot {
+  background: #dc2626;
+}
+
+.itdo-audit-timeline__item.is-selected {
+  border-color: var(--color-primary-500, #f97316);
+}
+
+.itdo-audit-timeline__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.itdo-audit-timeline__action {
+  font-weight: 600;
+  color: var(--color-neutral-900, #111827);
+}
+
+.itdo-audit-timeline__time {
+  font-size: 0.75rem;
+  color: var(--color-neutral-500, #6b7280);
+}
+
+.itdo-audit-timeline__actor {
+  margin: 0.125rem 0 0;
+  font-size: 0.75rem;
+  color: var(--color-neutral-600, #4b5563);
+}
+
+.itdo-audit-timeline__summary {
+  margin: 0.25rem 0 0;
+  color: var(--color-neutral-800, #1f2937);
+  font-size: 0.8125rem;
+}
+
+.itdo-audit-timeline__meta {
+  margin-top: 0.375rem;
+  font-size: 0.75rem;
+  color: var(--color-neutral-500, #6b7280);
+}
+
+.itdo-audit-timeline.is-compact .itdo-audit-timeline__item-button,
+.itdo-audit-timeline.is-compact .itdo-audit-timeline__item-static {
+  padding: 0.5rem;
+}
+
+.itdo-diff-viewer {
+  border: 1px solid var(--color-border-default, #e5e7eb);
+  border-radius: 0.5rem;
+  overflow: hidden;
+  background: #ffffff;
+}
+
+.itdo-diff-viewer__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--color-border-default, #e5e7eb);
+  background: #f9fafb;
+}
+
+.itdo-diff-viewer__header h3,
+.itdo-diff-viewer__header p {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--color-neutral-700, #374151);
+}
+
+.itdo-diff-viewer__surface {
+  overflow: auto;
+  max-height: 22rem;
+}
+
+.itdo-diff-viewer__pre {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
+  font-size: 0.75rem;
+}
+
+.itdo-diff-viewer__line {
+  display: grid;
+  grid-template-columns: 2.5rem 2.5rem 1rem 1fr;
+  gap: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  white-space: pre;
+}
+
+.itdo-diff-viewer__line-number,
+.itdo-diff-viewer__prefix {
+  color: var(--color-neutral-500, #6b7280);
+}
+
+.itdo-diff-viewer__line--add {
+  background: #ecfdf5;
+}
+
+.itdo-diff-viewer__line--add .itdo-diff-viewer__prefix {
+  color: #059669;
+}
+
+.itdo-diff-viewer__line--remove {
+  background: #fef2f2;
+}
+
+.itdo-diff-viewer__line--remove .itdo-diff-viewer__prefix {
+  color: #dc2626;
+}
+
+.itdo-diff-viewer__code {
+  font-family: inherit;
+  color: var(--color-neutral-800, #1f2937);
+}
+
+.itdo-diff-viewer__collapse {
+  padding: 0.5rem 0.75rem;
+  border-top: 1px solid var(--color-border-default, #e5e7eb);
+  background: #f9fafb;
+}
+
+.itdo-diff-viewer__collapse button {
+  border: 1px solid var(--color-neutral-300, #d1d5db);
+  border-radius: 999px;
+  background: #ffffff;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.itdo-diff-viewer.is-compact .itdo-diff-viewer__surface {
+  max-height: 16rem;
+}

--- a/src/patterns/AuditTimeline/AuditTimeline.css
+++ b/src/patterns/AuditTimeline/AuditTimeline.css
@@ -1,6 +1,6 @@
 .itdo-audit-timeline {
   display: grid;
-  gap: 0.75rem;
+  gap: var(--space-6);
 }
 
 .itdo-audit-timeline__empty {
@@ -10,7 +10,7 @@
 
 .itdo-audit-timeline__group {
   display: grid;
-  gap: 0.375rem;
+  gap: var(--space-3);
 }
 
 .itdo-audit-timeline__date {
@@ -24,13 +24,13 @@
   padding: 0;
   list-style: none;
   display: grid;
-  gap: 0.5rem;
+  gap: var(--space-4);
 }
 
 .itdo-audit-timeline__item {
   border: 1px solid var(--color-border-default, #e5e7eb);
-  border-radius: 0.5rem;
-  background: var(--color-neutral-0, #ffffff);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-base);
 }
 
 .itdo-audit-timeline__item-button,
@@ -40,9 +40,9 @@
   background: transparent;
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 0.5rem;
+  gap: var(--space-4);
   text-align: left;
-  padding: 0.625rem 0.75rem;
+  padding: var(--space-6);
 }
 
 .itdo-audit-timeline__item-button {
@@ -54,28 +54,28 @@
 }
 
 .itdo-audit-timeline__dot {
-  width: 0.5rem;
-  height: 0.5rem;
+  width: var(--space-4);
+  height: var(--space-4);
   border-radius: 999px;
-  margin-top: 0.375rem;
+  margin-top: var(--space-3);
   background: var(--color-neutral-400, #9ca3af);
 }
 
 .itdo-audit-timeline__item--info .itdo-audit-timeline__dot {
-  background: #2563eb;
+  background: var(--color-status-info-border);
 }
 
 .itdo-audit-timeline__item--success .itdo-audit-timeline__dot {
-  background: #059669;
+  background: var(--color-status-success-border);
 }
 
 .itdo-audit-timeline__item--warning .itdo-audit-timeline__dot {
-  background: #d97706;
+  background: var(--color-status-warning-border);
 }
 
 .itdo-audit-timeline__item--error .itdo-audit-timeline__dot,
 .itdo-audit-timeline__item--critical .itdo-audit-timeline__dot {
-  background: #dc2626;
+  background: var(--color-status-error-border);
 }
 
 .itdo-audit-timeline__item.is-selected {
@@ -86,7 +86,7 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: var(--space-4);
 }
 
 .itdo-audit-timeline__action {
@@ -100,43 +100,43 @@
 }
 
 .itdo-audit-timeline__actor {
-  margin: 0.125rem 0 0;
+  margin: var(--space-1) 0 0;
   font-size: 0.75rem;
   color: var(--color-neutral-600, #4b5563);
 }
 
 .itdo-audit-timeline__summary {
-  margin: 0.25rem 0 0;
+  margin: var(--space-2) 0 0;
   color: var(--color-neutral-800, #1f2937);
   font-size: 0.8125rem;
 }
 
 .itdo-audit-timeline__meta {
-  margin-top: 0.375rem;
+  margin-top: var(--space-3);
   font-size: 0.75rem;
   color: var(--color-neutral-500, #6b7280);
 }
 
 .itdo-audit-timeline.is-compact .itdo-audit-timeline__item-button,
 .itdo-audit-timeline.is-compact .itdo-audit-timeline__item-static {
-  padding: 0.5rem;
+  padding: var(--space-4);
 }
 
 .itdo-diff-viewer {
   border: 1px solid var(--color-border-default, #e5e7eb);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   overflow: hidden;
-  background: #ffffff;
+  background: var(--color-bg-base);
 }
 
 .itdo-diff-viewer__header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-6);
   border-bottom: 1px solid var(--color-border-default, #e5e7eb);
-  background: #f9fafb;
+  background: var(--color-bg-surface);
 }
 
 .itdo-diff-viewer__header h3,
@@ -151,7 +151,7 @@
   max-height: 22rem;
 }
 
-.itdo-diff-viewer__pre {
+.itdo-diff-viewer__rows {
   margin: 0;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
     'Courier New', monospace;
@@ -161,8 +161,8 @@
 .itdo-diff-viewer__line {
   display: grid;
   grid-template-columns: 2.5rem 2.5rem 1rem 1fr;
-  gap: 0.25rem;
-  padding: 0.125rem 0.5rem;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-4);
   white-space: pre;
 }
 
@@ -172,19 +172,19 @@
 }
 
 .itdo-diff-viewer__line--add {
-  background: #ecfdf5;
+  background: var(--color-status-success-bg);
 }
 
 .itdo-diff-viewer__line--add .itdo-diff-viewer__prefix {
-  color: #059669;
+  color: var(--color-status-success-fg);
 }
 
 .itdo-diff-viewer__line--remove {
-  background: #fef2f2;
+  background: var(--color-status-error-bg);
 }
 
 .itdo-diff-viewer__line--remove .itdo-diff-viewer__prefix {
-  color: #dc2626;
+  color: var(--color-status-error-fg);
 }
 
 .itdo-diff-viewer__code {
@@ -193,16 +193,16 @@
 }
 
 .itdo-diff-viewer__collapse {
-  padding: 0.5rem 0.75rem;
+  padding: var(--space-4) var(--space-6);
   border-top: 1px solid var(--color-border-default, #e5e7eb);
-  background: #f9fafb;
+  background: var(--color-bg-surface);
 }
 
 .itdo-diff-viewer__collapse button {
   border: 1px solid var(--color-neutral-300, #d1d5db);
   border-radius: 999px;
-  background: #ffffff;
-  padding: 0.25rem 0.5rem;
+  background: var(--color-bg-base);
+  padding: var(--space-2) var(--space-4);
   font-size: 0.75rem;
   cursor: pointer;
 }

--- a/src/patterns/AuditTimeline/AuditTimeline.stories.tsx
+++ b/src/patterns/AuditTimeline/AuditTimeline.stories.tsx
@@ -1,0 +1,101 @@
+import { useMemo, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fireEvent, within } from 'storybook/test';
+import { AuditTimeline } from './AuditTimeline';
+import { DiffViewer } from './DiffViewer';
+import type { AuditEvent } from './AuditTimeline.types';
+
+const events: AuditEvent[] = [
+  {
+    id: 'evt-1',
+    time: '2026-02-11T08:15:00Z',
+    actor: 'system.bot',
+    action: 'Policy updated',
+    target: 'approval-template',
+    summary: 'Condition threshold changed from 50k to 100k.',
+    tone: 'warning',
+  },
+  {
+    id: 'evt-2',
+    time: '2026-02-11T09:20:00Z',
+    actor: 'k.ota',
+    action: 'Manual override',
+    target: 'invoice INV-2026-0012',
+    summary: 'Escalated to director route.',
+    tone: 'critical',
+  },
+  {
+    id: 'evt-3',
+    time: '2026-02-10T14:05:00Z',
+    actor: 'workflow.engine',
+    action: 'Sync completed',
+    target: 'vendor policy cache',
+    summary: 'No conflict detected.',
+    tone: 'success',
+  },
+];
+
+const diffMap: Record<string, { before: unknown; after: unknown }> = {
+  'evt-1': {
+    before: { minAmount: 50000, approverRole: 'manager', requireAck: false },
+    after: { minAmount: 100000, approverRole: 'director', requireAck: true },
+  },
+  'evt-2': {
+    before: 'status=pending\nroute=manager\nnote=none',
+    after: 'status=overridden\nroute=director\nnote=manual escalation',
+  },
+  'evt-3': {
+    before: { cacheVersion: 7, staleKeys: ['VN-42'] },
+    after: { cacheVersion: 8, staleKeys: [] },
+  },
+};
+
+const meta: Meta<typeof AuditTimeline> = {
+  title: 'Patterns/AuditTimeline',
+  component: AuditTimeline,
+};
+
+export default meta;
+type Story = StoryObj<typeof AuditTimeline>;
+
+export const TimelineWithLinkedDiff: Story = {
+  render: () => {
+    const [selectedId, setSelectedId] = useState(events[0].id);
+    const selectedDiff = useMemo(() => diffMap[selectedId], [selectedId]);
+
+    return (
+      <div style={{ display: 'grid', gap: 16 }}>
+        <AuditTimeline
+          events={events}
+          selectedEventId={selectedId}
+          onSelectEvent={(event) => setSelectedId(event.id)}
+          groupByDate
+        />
+        <DiffViewer
+          format={selectedId === 'evt-2' ? 'text' : 'json'}
+          before={selectedDiff.before}
+          after={selectedDiff.after}
+        />
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    fireEvent.click(canvas.getByRole('button', { name: /Manual override/i }));
+    await expect(canvas.getByText(/route=director/i)).toBeInTheDocument();
+  },
+};
+
+export const CompactMode: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 12 }}>
+      <AuditTimeline events={events} compact selectedEventId="evt-1" groupByDate={false} />
+      <DiffViewer
+        compact
+        format="text"
+        before={'line1\nline2\nline3\nline4\nline5'}
+        after={'line1\nline2-updated\nline3\nline4\nline5\nline6'}
+      />
+    </div>
+  ),
+};

--- a/src/patterns/AuditTimeline/AuditTimeline.test.tsx
+++ b/src/patterns/AuditTimeline/AuditTimeline.test.tsx
@@ -91,4 +91,27 @@ describe('DiffViewer', () => {
     expect(screen.getByText('"threshold": 10,')).toBeInTheDocument();
     expect(screen.getByText('"threshold": 20,')).toBeInTheDocument();
   });
+
+  it('does not collapse when maxVisibleLines is non-positive', () => {
+    const before = Array.from({ length: 5 }, (_, index) => `before-${index}`).join('\n');
+    const after = Array.from({ length: 5 }, (_, index) => `after-${index}`).join('\n');
+
+    render(<DiffViewer before={before} after={after} maxVisibleLines={0} />);
+
+    expect(screen.queryByRole('button', { name: /Show .* more lines/i })).not.toBeInTheDocument();
+    expect(screen.getByText('before-4')).toBeInTheDocument();
+    expect(screen.getByText('after-4')).toBeInTheDocument();
+  });
+
+  it('normalizes CRLF newlines before diffing', () => {
+    const { container } = render(<DiffViewer before={'a\r\nb'} after={'a\nb'} />);
+
+    expect(container.querySelectorAll('.itdo-diff-viewer__line--add')).toHaveLength(0);
+    expect(container.querySelectorAll('.itdo-diff-viewer__line--remove')).toHaveLength(0);
+  });
+
+  it('accepts undefined before/after values', () => {
+    render(<DiffViewer />);
+    expect(screen.getByText('Diff (TEXT)')).toBeInTheDocument();
+  });
 });

--- a/src/patterns/AuditTimeline/AuditTimeline.test.tsx
+++ b/src/patterns/AuditTimeline/AuditTimeline.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { AuditTimeline } from './AuditTimeline';
+import { DiffViewer } from './DiffViewer';
+import type { AuditEvent } from './AuditTimeline.types';
+
+const events: AuditEvent[] = [
+  {
+    id: 'e-1',
+    time: '2026-02-11T08:15:00Z',
+    actor: 'system',
+    action: 'Policy updated',
+    target: 'approval',
+    summary: 'Threshold changed.',
+    tone: 'warning',
+  },
+  {
+    id: 'e-2',
+    time: '2026-02-11T09:00:00Z',
+    actor: 'admin',
+    action: 'Manual override',
+    target: 'invoice',
+    tone: 'critical',
+  },
+  {
+    id: 'e-3',
+    time: '2026-02-10T11:00:00Z',
+    actor: 'system',
+    action: 'Sync complete',
+    tone: 'success',
+  },
+];
+
+describe('AuditTimeline', () => {
+  it('groups events by date and emits selected event', () => {
+    const onSelectEvent = jest.fn();
+
+    render(<AuditTimeline events={events} onSelectEvent={onSelectEvent} groupByDate />);
+
+    expect(screen.getByRole('heading', { name: '2026-02-11' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '2026-02-10' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Manual override/i }));
+    expect(onSelectEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'e-2',
+      })
+    );
+  });
+
+  it('renders empty state fallback', () => {
+    render(<AuditTimeline events={[]} />);
+    expect(screen.getByText('No audit events.')).toBeInTheDocument();
+  });
+});
+
+describe('DiffViewer', () => {
+  it('highlights add/remove lines for text diff', () => {
+    render(
+      <DiffViewer before={'status=pending\nroute=manager'} after={'status=approved\nroute=manager'} />
+    );
+
+    expect(screen.getByText('status=pending')).toBeInTheDocument();
+    expect(screen.getByText('status=approved')).toBeInTheDocument();
+
+    const removedLine = screen.getByText('status=pending').closest('.itdo-diff-viewer__line');
+    const addedLine = screen.getByText('status=approved').closest('.itdo-diff-viewer__line');
+    expect(removedLine).toHaveClass('itdo-diff-viewer__line--remove');
+    expect(addedLine).toHaveClass('itdo-diff-viewer__line--add');
+  });
+
+  it('collapses long output and can expand', () => {
+    const before = Array.from({ length: 30 }, (_, index) => `before-${index}`).join('\n');
+    const after = Array.from({ length: 30 }, (_, index) => `after-${index}`).join('\n');
+
+    render(<DiffViewer before={before} after={after} maxVisibleLines={10} />);
+
+    expect(screen.getByRole('button', { name: /Show .* more lines/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Show .* more lines/i }));
+    expect(screen.getByRole('button', { name: 'Show less' })).toBeInTheDocument();
+  });
+
+  it('supports json mode formatting', () => {
+    render(
+      <DiffViewer
+        format="json"
+        before={{ threshold: 10, enabled: false }}
+        after={{ threshold: 20, enabled: true }}
+      />
+    );
+
+    expect(screen.getByText('"threshold": 10,')).toBeInTheDocument();
+    expect(screen.getByText('"threshold": 20,')).toBeInTheDocument();
+  });
+});

--- a/src/patterns/AuditTimeline/AuditTimeline.tsx
+++ b/src/patterns/AuditTimeline/AuditTimeline.tsx
@@ -5,7 +5,10 @@ import './AuditTimeline.css';
 const toDateKey = (time: string) => {
   const parsed = new Date(time);
   if (!Number.isNaN(parsed.getTime())) {
-    return parsed.toISOString().slice(0, 10);
+    const year = parsed.getFullYear();
+    const month = String(parsed.getMonth() + 1).padStart(2, '0');
+    const day = String(parsed.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
   }
   return time.slice(0, 10);
 };

--- a/src/patterns/AuditTimeline/AuditTimeline.tsx
+++ b/src/patterns/AuditTimeline/AuditTimeline.tsx
@@ -1,0 +1,106 @@
+import clsx from 'clsx';
+import type { AuditEvent, AuditTimelineProps } from './AuditTimeline.types';
+import './AuditTimeline.css';
+
+const toDateKey = (time: string) => {
+  const parsed = new Date(time);
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed.toISOString().slice(0, 10);
+  }
+  return time.slice(0, 10);
+};
+
+const toDisplayTime = (time: string) => {
+  const parsed = new Date(time);
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed.toLocaleString();
+  }
+  return time;
+};
+
+const groupEvents = (events: AuditEvent[]) => {
+  const map = new Map<string, AuditEvent[]>();
+  events.forEach((event) => {
+    const key = toDateKey(event.time);
+    const current = map.get(key) ?? [];
+    current.push(event);
+    map.set(key, current);
+  });
+  return Array.from(map.entries()).map(([date, items]) => ({ date, items }));
+};
+
+export const AuditTimeline = ({
+  events,
+  onSelectEvent,
+  selectedEventId,
+  compact = false,
+  groupByDate = true,
+  className,
+  emptyState,
+}: AuditTimelineProps) => {
+  if (events.length === 0) {
+    return (
+      <section className={clsx('itdo-audit-timeline', className)}>
+        {emptyState ?? <p className="itdo-audit-timeline__empty">No audit events.</p>}
+      </section>
+    );
+  }
+
+  const groups = groupByDate ? groupEvents(events) : [{ date: 'All events', items: events }];
+
+  return (
+    <section className={clsx('itdo-audit-timeline', { 'is-compact': compact }, className)}>
+      {groups.map((group) => (
+        <div key={group.date} className="itdo-audit-timeline__group">
+          {groupByDate && <h3 className="itdo-audit-timeline__date">{group.date}</h3>}
+          <ul className="itdo-audit-timeline__list">
+            {group.items.map((event) => {
+              const isSelected = selectedEventId === event.id;
+              const content = (
+                <>
+                  <span className="itdo-audit-timeline__dot" aria-hidden="true" />
+                  <div className="itdo-audit-timeline__content">
+                    <header className="itdo-audit-timeline__header">
+                      <span className="itdo-audit-timeline__action">
+                        {event.action}
+                        {event.target ? ` · ${event.target}` : ''}
+                      </span>
+                      <time className="itdo-audit-timeline__time">{toDisplayTime(event.time)}</time>
+                    </header>
+                    <p className="itdo-audit-timeline__actor">{event.actor}</p>
+                    {event.summary && <p className="itdo-audit-timeline__summary">{event.summary}</p>}
+                    {event.meta && <div className="itdo-audit-timeline__meta">{event.meta}</div>}
+                  </div>
+                </>
+              );
+
+              return (
+                <li
+                  key={event.id}
+                  className={clsx(
+                    'itdo-audit-timeline__item',
+                    `itdo-audit-timeline__item--${event.tone ?? 'default'}`,
+                    { 'is-selected': isSelected }
+                  )}
+                >
+                  {onSelectEvent ? (
+                    <button
+                      type="button"
+                      className="itdo-audit-timeline__item-button"
+                      aria-pressed={isSelected}
+                      onClick={() => onSelectEvent(event)}
+                    >
+                      {content}
+                    </button>
+                  ) : (
+                    <div className="itdo-audit-timeline__item-static">{content}</div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
+    </section>
+  );
+};

--- a/src/patterns/AuditTimeline/AuditTimeline.types.ts
+++ b/src/patterns/AuditTimeline/AuditTimeline.types.ts
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+
+export type AuditEventTone = 'default' | 'info' | 'success' | 'warning' | 'error' | 'critical';
+
+export interface AuditEvent {
+  id: string;
+  time: string;
+  actor: string;
+  action: string;
+  target?: string;
+  summary?: string;
+  tone?: AuditEventTone;
+  meta?: ReactNode;
+}
+
+export interface AuditTimelineProps {
+  events: AuditEvent[];
+  onSelectEvent?: (event: AuditEvent) => void;
+  selectedEventId?: string;
+  compact?: boolean;
+  groupByDate?: boolean;
+  className?: string;
+  emptyState?: ReactNode;
+}
+
+export type DiffViewerFormat = 'text' | 'json';
+
+export interface DiffViewerProps {
+  before: unknown;
+  after: unknown;
+  format?: DiffViewerFormat;
+  compact?: boolean;
+  maxVisibleLines?: number;
+  className?: string;
+}

--- a/src/patterns/AuditTimeline/AuditTimeline.types.ts
+++ b/src/patterns/AuditTimeline/AuditTimeline.types.ts
@@ -26,8 +26,8 @@ export interface AuditTimelineProps {
 export type DiffViewerFormat = 'text' | 'json';
 
 export interface DiffViewerProps {
-  before: unknown;
-  after: unknown;
+  before?: unknown;
+  after?: unknown;
   format?: DiffViewerFormat;
   compact?: boolean;
   maxVisibleLines?: number;

--- a/src/patterns/AuditTimeline/DiffViewer.tsx
+++ b/src/patterns/AuditTimeline/DiffViewer.tsx
@@ -1,0 +1,165 @@
+import { useMemo, useState } from 'react';
+import clsx from 'clsx';
+import type { DiffViewerProps } from './AuditTimeline.types';
+import './AuditTimeline.css';
+
+type DiffLineType = 'context' | 'add' | 'remove';
+
+interface DiffLine {
+  type: DiffLineType;
+  beforeLine?: number;
+  afterLine?: number;
+  text: string;
+}
+
+const stringifySource = (value: unknown, format: 'text' | 'json') => {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    if (format === 'json') {
+      try {
+        const parsed = JSON.parse(value);
+        return JSON.stringify(parsed, null, 2);
+      } catch {
+        return value;
+      }
+    }
+    return value;
+  }
+  if (format === 'json') {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+};
+
+const toLines = (value: string) => value.split('\n');
+
+const createDiff = (beforeLines: string[], afterLines: string[]): DiffLine[] => {
+  const diff: DiffLine[] = [];
+  let beforeIndex = 0;
+  let afterIndex = 0;
+
+  while (beforeIndex < beforeLines.length || afterIndex < afterLines.length) {
+    const beforeLine = beforeLines[beforeIndex];
+    const afterLine = afterLines[afterIndex];
+
+    if (beforeLine === afterLine) {
+      diff.push({
+        type: 'context',
+        beforeLine: beforeIndex + 1,
+        afterLine: afterIndex + 1,
+        text: beforeLine ?? '',
+      });
+      beforeIndex += 1;
+      afterIndex += 1;
+      continue;
+    }
+
+    const nextAfter = afterLines[afterIndex + 1];
+    const nextBefore = beforeLines[beforeIndex + 1];
+
+    if (beforeLine === nextAfter) {
+      diff.push({
+        type: 'add',
+        afterLine: afterIndex + 1,
+        text: afterLine ?? '',
+      });
+      afterIndex += 1;
+      continue;
+    }
+
+    if (afterLine === nextBefore) {
+      diff.push({
+        type: 'remove',
+        beforeLine: beforeIndex + 1,
+        text: beforeLine ?? '',
+      });
+      beforeIndex += 1;
+      continue;
+    }
+
+    if (beforeLine !== undefined) {
+      diff.push({
+        type: 'remove',
+        beforeLine: beforeIndex + 1,
+        text: beforeLine,
+      });
+      beforeIndex += 1;
+    }
+
+    if (afterLine !== undefined) {
+      diff.push({
+        type: 'add',
+        afterLine: afterIndex + 1,
+        text: afterLine,
+      });
+      afterIndex += 1;
+    }
+  }
+
+  return diff;
+};
+
+export const DiffViewer = ({
+  before,
+  after,
+  format = 'text',
+  compact = false,
+  maxVisibleLines = 200,
+  className,
+}: DiffViewerProps) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const lines = useMemo(() => {
+    const beforeText = stringifySource(before, format);
+    const afterText = stringifySource(after, format);
+    return createDiff(toLines(beforeText), toLines(afterText));
+  }, [after, before, format]);
+
+  const threshold = compact ? Math.min(maxVisibleLines, 80) : maxVisibleLines;
+  const canCollapse = lines.length > threshold;
+  const visibleLines = !canCollapse || expanded ? lines : lines.slice(0, threshold);
+  const hiddenCount = canCollapse ? lines.length - threshold : 0;
+
+  return (
+    <section className={clsx('itdo-diff-viewer', { 'is-compact': compact }, className)}>
+      <header className="itdo-diff-viewer__header">
+        <h3>Diff ({format.toUpperCase()})</h3>
+        <p>{lines.length} lines</p>
+      </header>
+      <div className="itdo-diff-viewer__surface" role="region" aria-label="Diff output">
+        <pre className="itdo-diff-viewer__pre">
+          {visibleLines.map((line, index) => (
+            <div
+              key={`${index}-${line.beforeLine ?? 0}-${line.afterLine ?? 0}`}
+              className={clsx('itdo-diff-viewer__line', `itdo-diff-viewer__line--${line.type}`)}
+            >
+              <span className="itdo-diff-viewer__line-number">
+                {line.beforeLine ?? ''}
+              </span>
+              <span className="itdo-diff-viewer__line-number">
+                {line.afterLine ?? ''}
+              </span>
+              <span className="itdo-diff-viewer__prefix">
+                {line.type === 'add' ? '+' : line.type === 'remove' ? '-' : ' '}
+              </span>
+              <code className="itdo-diff-viewer__code">{line.text || ' '}</code>
+            </div>
+          ))}
+        </pre>
+      </div>
+      {canCollapse && (
+        <div className="itdo-diff-viewer__collapse">
+          <button type="button" onClick={() => setExpanded((previous) => !previous)}>
+            {expanded ? 'Show less' : `Show ${hiddenCount} more lines`}
+          </button>
+        </div>
+      )}
+    </section>
+  );
+};

--- a/src/patterns/AuditTimeline/index.ts
+++ b/src/patterns/AuditTimeline/index.ts
@@ -1,0 +1,3 @@
+export * from './AuditTimeline';
+export * from './DiffViewer';
+export * from './AuditTimeline.types';

--- a/src/patterns/index.ts
+++ b/src/patterns/index.ts
@@ -16,3 +16,4 @@ export * from './AttachmentField';
 export * from './FormWizard';
 export * from './UndoToast';
 export * from './StatePreset';
+export * from './AuditTimeline';


### PR DESCRIPTION
## 概要
- `AuditTimeline` と `DiffViewer` を `patterns` に追加
- `events[]` の日付グルーピング、tone表示、選択イベント通知を実装
- `DiffViewer` で text/json の before/after 差分を追加・削除ハイライト表示
- 長文/大JSON向けに `maxVisibleLines` と折りたたみ展開を実装
- `docs/audit-timeline-guidelines.md` を追加し、EventLogとの棲み分けを明文化

## 受入条件との対応
- EventLogとの棲み分け docs: `docs/audit-timeline-guidelines.md`
- 長文/大JSON表示: `maxVisibleLines` + `Show more/less`
- Story連動: `TimelineWithLinkedDiff`（タイムライン選択と差分表示を連動）

## 検証
- `npm test -- AuditTimeline --runInBand`
- `npm run lint`
- `npm run type-check`
- `npm run build:lib`

Closes #80
