### PR TITLE
chore(release): bump @itdo/design-system to v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.1.0 - 2026-02-11
+
+### Added
+- `DateRangePicker` / `DateTimeRangePicker` patterns with presets, range validation, and timezone-aware datetime support.
+- `EntityReferencePicker` pattern for reusable internal entity reference search/select flows.
+- `MentionComposer` pattern for unified mention/ack/attachment-aware message composition.
+- `Drawer` pattern for context-preserving detail and edit flows from list screens.
+- `PolicyFormBuilder` pattern for declarative admin policy forms.
+- `AuditTimeline` / `DiffViewer` patterns for investigation-oriented history and change inspection UX.
+- New usage guidelines for the above patterns under `docs/*-guidelines.md`.
+
 ## 1.0.3 - 2026-02-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - `Drawer` pattern for context-preserving detail and edit flows from list screens.
 - `PolicyFormBuilder` pattern for declarative admin policy forms.
 - `AuditTimeline` / `DiffViewer` patterns for investigation-oriented history and change inspection UX.
-- New usage guidelines for the above patterns under `docs/*-guidelines.md`.
+- New usage guidelines for `DateRangePicker`, `EntityReferencePicker`, `Drawer`, `PolicyFormBuilder`, and `AuditTimeline` under `docs/*-guidelines.md`.
 
 ## 1.0.3 - 2026-02-06
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@itdo/design-system",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@itdo/design-system",
-      "version": "1.0.4",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itdo/design-system",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "ITDO Design System - Enterprise-Grade Component Library",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
## Summary
- bump package version to `1.1.0`
- add changelog entry for Issue #75-80 feature wave

## Verification
- npm run type-check
- npm run build
- npm pack --dry-run
- Publish workflow (workflow_dispatch): https://github.com/itdojp/itdo-design-system/actions/runs/21926541800

## Notes
- `@itdo/design-system@1.1.0` is already published to npm via Trusted Publishing (OIDC).